### PR TITLE
Feature to make YouTube player have responsive sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ $ npm install svelte-youtube
   id={string}                       // defaults -> null
   class={string}                    // defaults -> null
   options={obj}                     // defaults -> {}
+  responsive={bool}                 // defaults -> false
 />
 ```
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,9 +10,9 @@
     "@rollup/plugin-node-resolve": "^6.0.0",
     "rollup": "^1.20.0",
     "rollup-plugin-livereload": "^1.0.0",
-    "rollup-plugin-svelte": "^5.0.3",
+    "rollup-plugin-svelte": "^6.1.1",
     "rollup-plugin-terser": "^5.1.2",
-    "svelte": "^3.0.0"
+    "svelte": "^3.37.0"
   },
   "dependencies": {
     "sirv-cli": "^0.4.4"

--- a/examples/rollup.config.js
+++ b/examples/rollup.config.js
@@ -12,7 +12,7 @@ export default {
 		sourcemap: true,
 		format: 'iife',
 		name: 'app',
-		file: 'public/build/bundle.js'
+		file: 'bundle.js'
 	},
 	plugins: [
 		svelte({

--- a/examples/src/App.svelte
+++ b/examples/src/App.svelte
@@ -10,13 +10,26 @@
 
 <main>
 	<h1>Svelte-YouTube</h1>
-	<p>Embedding a single video:</p>
+	<h3>Embedding a single video:</h3>
 	<YouTube {videoId}
 		on:ready={logEvent('ready')}
 		on:play={logEvent('play')}
 		on:pause={logEvent('pause')}
 		on:end={logEvent('end')}
 		/>
+	
+	<h3>Embedding a responsive video component:</h3>
+	<p>By default, svelte-youtube components are <strong>not</strong> responsive.</p>
+	<p>
+		The responsive comonent will take 100% of the container's width, 
+		so style your container using responsive units.
+	</p>
+	<YouTube {videoId} responsive={true}
+			on:ready={logEvent('ready')}
+			on:play={logEvent('play')}
+			on:pause={logEvent('pause')}
+			on:end={logEvent('end')}
+	/>
 </main>
 
 <style>

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "devDependencies": {
     "rollup": "^1.11.0",
     "rollup-plugin-node-resolve": "^4.0.0",
-    "rollup-plugin-svelte": "^5.0.0",
-    "svelte": "^3.0.0"
+    "rollup-plugin-svelte": "^6.1.1",
+    "svelte": "3.37.0"
   },
   "peerDependencies": {
-    "svelte": "^3.0.0"
+    "svelte": "^3.37.0"
   },
   "keywords": [
     "svelte",

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -142,7 +142,10 @@
 </script>
 
 <div class={(className ? className : "") + (responsive ? " responsive-container" : "")}>
-  <div id={id} class={responsive ? "responsive-player" : ""} bind:this={playerElem}></div>
+  <div id={id} bind:this={playerElem}
+    class={responsive ? "responsive-player" : ""} 
+  >
+  </div>
 </div>
 
 <style>

--- a/src/index.svelte
+++ b/src/index.svelte
@@ -23,6 +23,7 @@
   export let id = undefined; // HTML element ID for player (optional)
   export let videoId;        // Youtube video ID (required)
   export let options = undefined; // YouTube player options (optional)
+  export let responsive = false;
 
   let className;             // HTML class names for container element
   let playerElem;            // player DOM element reference
@@ -140,6 +141,22 @@
   }
 </script>
 
-<div class={className}>
-  <div id={id} bind:this={playerElem}></div>
+<div class={(className ? className : "") + (responsive ? " responsive-container" : "")}>
+  <div id={id} class={responsive ? "responsive-player" : ""} bind:this={playerElem}></div>
 </div>
+
+<style>
+  .responsive-container {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+  }
+  .responsive-player, #resp {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+</style>


### PR DESCRIPTION
This is a PR to add a feature to svelte-youtube that allows users to specify if they want their player to have responsive sizing.

I've also added an example of responsive sizing to the existing `example/` directory